### PR TITLE
image full path added to database

### DIFF
--- a/src/handlers/project.ts
+++ b/src/handlers/project.ts
@@ -159,3 +159,25 @@ export const getProjectImages = async (req: Request, res: Response) => {
 
   res.status(200).json(data);
 };
+
+export const updateProjectImageFullPath = async (req: Request, res: Response) => {
+  const { projectId } = req.params;
+  const { imageFullPath } = req.body;
+  const userId = res.locals.user.id;
+
+  if (!imageFullPath) {
+    return res.status(400).json({ error: "Image URL is required" });
+  }
+
+  const { data, error } = await supabase
+    .from("projects")
+    .update({ imageFullPath })
+    .eq("id", projectId)
+    .eq("created_by", userId);
+
+  if (error) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  res.status(200).json({ message: "Project image URL updated successfully", data });
+};

--- a/src/routes/project.ts
+++ b/src/routes/project.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { getProjects, findProject, updateProject, deleteProject, uploadImage, createProjects, getProjectImages } from "../handlers/project";
+import { getProjects, findProject, updateProject, deleteProject, uploadImage, createProjects, getProjectImages, updateProjectImageFullPath } from "../handlers/project";
 import { getScansByProjectId } from "../handlers/scan";
 import { verifyToken } from "../middleware/auth";
 import { saveEnergyResult, getEnergyResult } from "../handlers/energy";
@@ -28,6 +28,9 @@ router.get("/:projectId/images", getProjectImages);
 
 // /api/projects/:projectId/images/:imageId
 router.post("/:projectId/images/:imageId", uploadImage);
+
+// /api/projects/:projectId/imageFullPath
+router.put("/:projectId/imageFullPath", updateProjectImageFullPath);
 
 // /api/projects/:projectId/scans
 router.get("/:projectId/scans", getScansByProjectId);


### PR DESCRIPTION
## 🐛 Problème
- Les imagesURL obtenu via les fullPath des images indiquant leurs positions dans le storage Supabase etait fetch à chaque affichage d'image ce qui causait des appels API redondants et une certaine baisse de perfomance.

## 🔧 Solution apportée
- Enregistrer le fullPath de l'image dans la table projet directement dans la base de donnes afin de ne pas devoir tout le temps fetch pour l'avoir.

## ✅ Tests effectués
- Vérification manuelle du formulaire (remplissage et soumission).
- Aucune erreur dans la console.